### PR TITLE
Add maven-surefire version to orbit pom file

### DIFF
--- a/orbit/pom.xml
+++ b/orbit/pom.xml
@@ -73,11 +73,17 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
 
     <properties>
         <exp.pkg.version.xmlschema>1.4.7-wso2v3</exp.pkg.version.xmlschema>
+        <maven.surefire.plugin.version>2.13</maven.surefire.plugin.version>
     </properties>
 
 </project>

--- a/xmlschema/pom.xml
+++ b/xmlschema/pom.xml
@@ -185,6 +185,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.13</version>
           <configuration>
             <includes>
               <include>**/*Test.java</include>


### PR DESCRIPTION
## Purpose
Fix the build break due to maven-surefire version

## Goals
Fix the build break due to maven-surefire version

## Approach
Set a compatible maven-surefire version.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A
 - Integration tests
   N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A